### PR TITLE
fix(LT-5139): add timeline comparer for position history events

### DIFF
--- a/client/MarginTrading.TradingHistory.Client/PositionEventComparerByTimeline.cs
+++ b/client/MarginTrading.TradingHistory.Client/PositionEventComparerByTimeline.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using MarginTrading.TradingHistory.Client.Models;
+
+namespace MarginTrading.TradingHistory.Client
+{
+    /// <summary>
+    /// Comparer for position events that sorts them in chronological order
+    /// taking care of possible timestamp collisions.
+    /// </summary>
+    public class PositionEventComparerByTimeline : IComparer<PositionEventContract>
+    {
+        public const short FirstLessThanSecond = -1;
+        public const short FirstGreaterThanSecond = 1;
+        public const short FirstEqualToSecond = 0;
+        
+        public int Compare(PositionEventContract x, PositionEventContract y)
+        {
+            if (ReferenceEquals(x, y)) return FirstEqualToSecond;
+            if (ReferenceEquals(null, y)) return FirstGreaterThanSecond;
+            if (ReferenceEquals(null, x)) return FirstLessThanSecond;
+
+            var samePositionId = x.Id.Equals(y.Id, StringComparison.OrdinalIgnoreCase);
+            return samePositionId
+                ? CompareEventsOfSamePosition(x, y)
+                : x.Timestamp.CompareTo(y.Timestamp);
+        }
+        
+        private static int CompareEventsOfSamePosition(PositionEventContract x, PositionEventContract y)
+        {
+            var historyTypeComparison = x.HistoryType.CompareTo(y.HistoryType);
+            var sameHistoryType = historyTypeComparison == FirstEqualToSecond;
+
+            return sameHistoryType
+                ? x.Timestamp.CompareTo(y.Timestamp)
+                : historyTypeComparison;
+        }
+    }
+}

--- a/tests/MarginTrading.TradingHistory.Tests/MarginTrading.TradingHistory.Tests.csproj
+++ b/tests/MarginTrading.TradingHistory.Tests/MarginTrading.TradingHistory.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/tests/MarginTrading.TradingHistory.Tests/PositionEventComparerByTimelineTestData.cs
+++ b/tests/MarginTrading.TradingHistory.Tests/PositionEventComparerByTimelineTestData.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using MarginTrading.TradingHistory.Client;
+using MarginTrading.TradingHistory.Client.Models;
+
+namespace MarginTrading.TradingHistory.Tests
+{
+    public static class PositionEventComparerByTimelineTestData
+    {
+        public static IEnumerable<object[]> AllHistoryTypeComparisons()
+        {
+            yield return new object[] { PositionHistoryTypeContract.Open, PositionHistoryTypeContract.Close, PositionEventComparerByTimeline.FirstLessThanSecond };
+            yield return new object[] { PositionHistoryTypeContract.Open, PositionHistoryTypeContract.PartiallyClose, PositionEventComparerByTimeline.FirstLessThanSecond };
+            yield return new object[] { PositionHistoryTypeContract.PartiallyClose, PositionHistoryTypeContract.Close, PositionEventComparerByTimeline.FirstLessThanSecond };
+            yield return new object[] { PositionHistoryTypeContract.Close, PositionHistoryTypeContract.Open, PositionEventComparerByTimeline.FirstGreaterThanSecond };
+            yield return new object[] { PositionHistoryTypeContract.Close, PositionHistoryTypeContract.PartiallyClose, PositionEventComparerByTimeline.FirstGreaterThanSecond };
+            yield return new object[] { PositionHistoryTypeContract.PartiallyClose, PositionHistoryTypeContract.Open, PositionEventComparerByTimeline.FirstGreaterThanSecond };
+            yield return new object[] { PositionHistoryTypeContract.Close, PositionHistoryTypeContract.Close, PositionEventComparerByTimeline.FirstEqualToSecond };
+            yield return new object[] { PositionHistoryTypeContract.PartiallyClose, PositionHistoryTypeContract.PartiallyClose, PositionEventComparerByTimeline.FirstEqualToSecond };
+            yield return new object[] { PositionHistoryTypeContract.Open, PositionHistoryTypeContract.Open, PositionEventComparerByTimeline.FirstEqualToSecond };
+        }
+    }
+}

--- a/tests/MarginTrading.TradingHistory.Tests/PositionEventComparerByTimelineTests.cs
+++ b/tests/MarginTrading.TradingHistory.Tests/PositionEventComparerByTimelineTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using AutoFixture.Xunit2;
+using MarginTrading.TradingHistory.Client;
+using MarginTrading.TradingHistory.Client.Models;
+using Xunit;
+
+namespace MarginTrading.TradingHistory.Tests
+{
+    public class PositionEventComparerByTimelineTests
+    {
+        private readonly PositionEventComparerByTimeline _comparer = new PositionEventComparerByTimeline();
+
+        [Fact]
+        public void Compare_WhenBothEventsAreNull_TheyAreEqual()
+        {
+            var result = _comparer.Compare(null, null);
+            
+            Assert.Equal(PositionEventComparerByTimeline.FirstEqualToSecond, result);
+        }
+
+        [Fact]
+        public void Compare_WhenFirstEventIsNull_ItIsLess()
+        {
+            var eventContract = new PositionEventContract();
+            var result = _comparer.Compare(null, eventContract);
+            
+            Assert.Equal(PositionEventComparerByTimeline.FirstLessThanSecond, result);
+        }
+
+        [Fact]
+        public void Compare_WhenSecondEventIsNull_NotNullEventIsGreater()
+        {
+            var eventContract = new PositionEventContract();
+            var result = _comparer.Compare(eventContract, null);
+            
+            Assert.Equal(PositionEventComparerByTimeline.FirstGreaterThanSecond, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(PositionEventComparerByTimelineTestData.AllHistoryTypeComparisons),
+            MemberType = typeof(PositionEventComparerByTimelineTestData))]
+        public void Compare_WhenEventsHaveSameId_HistoryTypeCompared(
+            PositionHistoryTypeContract firstEventType,
+            PositionHistoryTypeContract secondEventType,
+            int expectedResult)
+        {
+            var firstEvent = new PositionEventContract { Id = "1", HistoryType = firstEventType };
+            var secondEvent = new PositionEventContract { Id = "1", HistoryType = secondEventType };
+            var result = _comparer.Compare(firstEvent, secondEvent);
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory, AutoData]
+        public void Compare_WhenEventsHaveSameIdAndSameHistoryType_ReturnsComparisonOfTimestamp(
+            string positionId,
+            PositionHistoryTypeContract historyType,
+            DateTime firstEventTimestamp,
+            DateTime secondEventTimestamp)
+        {
+            var firstEvent = new PositionEventContract
+            {
+                Id = positionId, HistoryType = historyType, Timestamp = firstEventTimestamp
+            };
+            var secondEvent = new PositionEventContract
+            {
+                Id = positionId, HistoryType = historyType, Timestamp = secondEventTimestamp
+            };
+            var actual = _comparer.Compare(firstEvent, secondEvent);
+            var expected = firstEventTimestamp.CompareTo(secondEventTimestamp);
+            
+            Assert.Equal(expected, actual);
+        }
+        
+        [Theory, AutoData]
+        public void Compare_WhenEventsHaveDifferentId_ReturnsComparisonOfTimestamp(
+            PositionEventContract firstEvent,
+            PositionEventContract secondEvent)
+        {
+            var actual = _comparer.Compare(firstEvent, secondEvent);
+            var expected = firstEvent.Timestamp.CompareTo(secondEvent.Timestamp);
+            
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
There is a comparer for `PositionEventContract` added to implement such events comparison and avoid `datetime` data type precision collisions.